### PR TITLE
feat(catalog): CSV ingest + CatalogIndex model + suggest API + admin …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tiptap/extension-underline": "^3.4.2",
         "@tiptap/react": "^3.4.2",
         "@tiptap/starter-kit": "^3.4.2",
+        "csv-parse": "^6.1.0",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.6",
         "isomorphic-dompurify": "^2.26.0",
@@ -6086,6 +6087,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tiptap/extension-underline": "^3.4.2",
     "@tiptap/react": "^3.4.2",
     "@tiptap/starter-kit": "^3.4.2",
+    "csv-parse": "^6.1.0",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.6",
     "isomorphic-dompurify": "^2.26.0",

--- a/prisma/migrations/20250918165650_catalog_index_lookup/migration.sql
+++ b/prisma/migrations/20250918165650_catalog_index_lookup/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "CatalogIndex" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sku" TEXT NOT NULL,
+    "imageId" TEXT,
+    "imagePath" TEXT,
+    "productTitle" TEXT,
+    "source" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CatalogIndex_sku_key" ON "CatalogIndex"("sku");
+
+-- CreateIndex
+CREATE INDEX "CatalogIndex_productTitle_idx" ON "CatalogIndex"("productTitle");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,3 +291,18 @@ model PromotionLine {
   @@index([culture])
   @@index([type])
 }
+
+
+model CatalogIndex {
+  id           String   @id @default(cuid())
+  sku          String   @unique
+  imageId      String?
+  imagePath    String?   // e.g., /images/abc.jpg or full URL
+  productTitle String?
+
+  source       String?   // optional: where the dump came from
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([productTitle])
+}

--- a/src/app/api/catalog/suggest/route.ts
+++ b/src/app/api/catalog/suggest/route.ts
@@ -1,0 +1,25 @@
+// src/app/api/catalog/suggest/route.ts
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = (searchParams.get("q") || "").trim();
+  if (!q) return NextResponse.json([], { status: 200 });
+
+  const rows = await prisma.catalogIndex.findMany({
+    where: {
+      OR: [
+        { sku:          { contains: q } },
+        { productTitle: { contains: q } },
+      ],
+    },
+    select: { sku: true, productTitle: true, imagePath: true, imageId: true },
+    take: 20,
+    orderBy: [{ sku: "asc" }],
+  });
+
+  return NextResponse.json(rows, { status: 200 });
+}

--- a/src/app/api/catalog/upload/route.ts
+++ b/src/app/api/catalog/upload/route.ts
@@ -1,0 +1,88 @@
+// src/app/api/catalog/upload/route.ts
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+import { parse } from "csv-parse";
+import { Readable } from "node:stream";
+
+export const runtime = "nodejs";
+// optional on Vercel: export const maxDuration = 60;
+
+const RowZ = z.object({
+  ImageID: z.string().optional().nullable(),
+  SKU: z.string().min(1),
+  Path: z.string().optional().nullable(),
+  ProductTitle: z.string().optional().nullable(),
+});
+
+function normalize(row: z.infer<typeof RowZ>) {
+  return {
+    sku: row.SKU.trim(),
+    imageId: row.ImageID?.toString().trim() || null,
+    imagePath: row.Path?.toString().trim() || null,
+    productTitle: row.ProductTitle?.toString().trim() || null,
+  };
+}
+
+export async function POST(req: Request) {
+  // simple auth: header must match env token (adjust to your auth later)
+  const token = req.headers.get("x-upload-token");
+  if (!process.env.CATALOG_UPLOAD_TOKEN || token !== process.env.CATALOG_UPLOAD_TOKEN) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const form = await req.formData();
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file is required" }, { status: 400 });
+  }
+
+  // Stream parse CSV (handles large files without loading whole text)
+  const buf = Buffer.from(await file.arrayBuffer());
+  const records: any[] = [];
+  const parser = parse(buf, { columns: true, trim: true, bom: true });
+
+  let ok = 0;
+  let bad = 0;
+  const batch: any[] = [];
+  const BATCH_SIZE = 500;
+
+  const flush = async () => {
+    if (!batch.length) return;
+    await prisma.$transaction(batch);
+    batch.length = 0;
+  };
+
+  for await (const rec of Readable.from(parser) as AsyncIterable<any>) {
+    const parsed = RowZ.safeParse(rec);
+    if (!parsed.success) {
+      bad++;
+      continue;
+    }
+    const row = normalize(parsed.data);
+    // upsert by SKU (unique)
+    batch.push(
+      prisma.catalogIndex.upsert({
+        where: { sku: row.sku },
+        update: {
+          imageId: row.imageId,
+          imagePath: row.imagePath,
+          productTitle: row.productTitle,
+          source: "csv-upload",
+        },
+        create: {
+          sku: row.sku,
+          imageId: row.imageId,
+          imagePath: row.imagePath,
+          productTitle: row.productTitle,
+          source: "csv-upload",
+        },
+      })
+    );
+    ok++;
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+  await flush();
+
+  return NextResponse.json({ ok, bad }, { status: 200 });
+}

--- a/src/app/catalog/upload/page.tsx
+++ b/src/app/catalog/upload/page.tsx
@@ -1,0 +1,50 @@
+// src/app/catalog/upload/page.tsx
+"use client";
+
+import { useState } from "react";
+
+export default function CatalogUploadPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [token, setToken] = useState("");
+  const [status, setStatus] = useState<null | string>(null);
+
+  async function upload() {
+    if (!file) return;
+    setStatus("Uploading…");
+    const fd = new FormData();
+    fd.append("file", file);
+    const res = await fetch("/api/catalog/upload", {
+      method: "POST",
+      headers: { "x-upload-token": token },
+      body: fd,
+    });
+    const json = await res.json();
+    if (!res.ok) {
+      setStatus(`Error: ${json?.error || res.statusText}`);
+      return;
+    }
+    setStatus(`Done. Imported: ${json.ok}, Skipped/Invalid: ${json.bad}`);
+  }
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4">
+      <h1 className="text-2xl font-semibold">Upload Catalog CSV</h1>
+      <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+      <input
+        type="password"
+        placeholder="Upload token"
+        className="block w-full rounded border px-3 py-2"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+      />
+      <button
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+        onClick={upload}
+        disabled={!file || !token}
+      >
+        Upload
+      </button>
+      {status && <p className="text-sm text-gray-700">{status}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
…uploader

- Schema: add CatalogIndex (sku, imageId, imagePath, productTitle).
- Migration: prisma/migrations/*catalog_index_lookup*/
- API: /api/catalog/upload (multipart CSV, batched upserts), /api/catalog/suggest (SKU/title search).
- UI: /catalog/upload admin page with token header.
- Deps: csv-parse for CSV ingestion.
- Notes: route runtime=nodejs; set CATALOG_UPLOAD_TOKEN in .env.local.